### PR TITLE
[STEP-11] 분산락 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -61,7 +61,12 @@ dependencies {
 
 	// Spring-Retry
 	implementation("org.springframework.retry:spring-retry")
-	implementation("org.springframework:spring-aspects")
+
+	// redis
+	implementation("org.springframework.boot:spring-boot-starter-aop")
+
+	// aop
+	implementation("org.redisson:redisson-spring-boot-starter:3.17.0")
 }
 
 tasks.withType<Test> {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,15 @@ services:
     volumes:
       - ./data/mysql/:/var/lib/mysql
 
+  redis:
+    image: redis:7.4.2
+    container_name: redis
+    ports:
+      - "6379:6379"
+    volumes:
+      - ./redis/data:/data
+      - ./redis/conf/redis.conf:/usr/local/conf/redis.conf
+
 networks:
   default:
     driver: bridge

--- a/src/main/java/kr/hhplus/be/server/common/lock/AopForTransaction.java
+++ b/src/main/java/kr/hhplus/be/server/common/lock/AopForTransaction.java
@@ -1,0 +1,15 @@
+package kr.hhplus.be.server.common.lock;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+public class AopForTransaction {
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object proceed(ProceedingJoinPoint joinPoint) throws Throwable {
+        return joinPoint.proceed();
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/common/lock/CustomSpringELParser.java
+++ b/src/main/java/kr/hhplus/be/server/common/lock/CustomSpringELParser.java
@@ -1,0 +1,20 @@
+package kr.hhplus.be.server.common.lock;
+
+import org.springframework.expression.ExpressionParser;
+import org.springframework.expression.spel.standard.SpelExpressionParser;
+import org.springframework.expression.spel.support.StandardEvaluationContext;
+
+public class CustomSpringELParser {
+
+    public static Object getDynamicValue(String[] parameterNames, Object[] args, String key) {
+
+        ExpressionParser parser = new SpelExpressionParser();
+        StandardEvaluationContext context = new StandardEvaluationContext();
+
+        for (int i = 0; i < parameterNames.length; i++) {
+            context.setVariable(parameterNames[i], args[i]);
+        }
+
+        return parser.parseExpression(key).getValue(context, Object.class);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/common/lock/DistributedLock.java
+++ b/src/main/java/kr/hhplus/be/server/common/lock/DistributedLock.java
@@ -1,0 +1,22 @@
+package kr.hhplus.be.server.common.lock;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DistributedLock {
+
+    String prefix() default "";
+
+    String key();
+
+    TimeUnit timeUnit() default TimeUnit.SECONDS;
+
+    long waitTime() default 5L;
+
+    long leaseTime() default 3L;
+}

--- a/src/main/java/kr/hhplus/be/server/common/lock/DistributedLockAop.java
+++ b/src/main/java/kr/hhplus/be/server/common/lock/DistributedLockAop.java
@@ -1,0 +1,58 @@
+package kr.hhplus.be.server.common.lock;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Method;
+
+@Order(1)
+@Aspect
+@Component
+@Slf4j
+public class DistributedLockAop {
+
+    private static final String REDISSON_LOCK_PREFIX = "lock:";
+
+    private final RedissonClient redissonClient;
+    private final AopForTransaction aopForTransaction;
+
+    public DistributedLockAop(RedissonClient redissonClient, AopForTransaction aopForTransaction) {
+        this.redissonClient = redissonClient;
+        this.aopForTransaction = aopForTransaction;
+    }
+
+    @Around("@annotation(kr.hhplus.be.server.common.lock.DistributedLock)")
+    public Object lock(final ProceedingJoinPoint joinPoint) throws Throwable {
+
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Method method = signature.getMethod();
+        DistributedLock distributedLock = method.getAnnotation(DistributedLock.class);
+
+        String key = REDISSON_LOCK_PREFIX + distributedLock.prefix() + CustomSpringELParser.getDynamicValue(signature.getParameterNames(), joinPoint.getArgs(), distributedLock.key());
+        RLock rLock = redissonClient.getLock(key);
+
+        try {
+            boolean available = rLock.tryLock(distributedLock.waitTime(), distributedLock.leaseTime(), distributedLock.timeUnit());
+            if (!available) {
+                return false;
+            }
+
+            return aopForTransaction.proceed(joinPoint);
+        } catch (InterruptedException e) {
+            throw new InterruptedException();
+        } finally {
+            try {
+                rLock.unlock();
+            } catch (IllegalMonitorStateException e) {
+                log.info("Redisson cache has been unlocked {} {}", method.getName(), distributedLock.key());
+            }
+        }
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/config/redis/RedissonConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/redis/RedissonConfig.java
@@ -1,0 +1,28 @@
+package kr.hhplus.be.server.config.redis;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    private static final String REDISSON_HOST_PREFIX = "redis://";
+
+    @Bean
+    public RedissonClient redissonClient() {
+
+        Config config = new Config();
+        config.useSingleServer().setAddress(REDISSON_HOST_PREFIX + host + ":" + port);
+        return Redisson.create(config);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponRepository.java
@@ -18,4 +18,6 @@ public interface CouponRepository {
     Optional<Coupon> findCouponByIdWithLock(long couponId);
 
     CouponIssue saveCouponIssue(CouponIssue couponIssue);
+
+    Optional<Coupon> findCouponById(long couponId);
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponRepositoryImpl.java
@@ -44,4 +44,9 @@ public class CouponRepositoryImpl implements CouponRepository {
     public CouponIssue saveCouponIssue(CouponIssue couponIssue) {
         return couponIssueJpaRepository.save(couponIssue);
     }
+
+    @Override
+    public Optional<Coupon> findCouponById(long couponId) {
+        return couponJpaRepository.findById(couponId);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,7 +20,10 @@ spring:
     properties:
       hibernate.timezone.default_storage: NORMALIZE_UTC
       hibernate.jdbc.time_zone: UTC
-
+  data:
+    redis:
+      host: localhost
+      port: 6379
 ---
 spring.config.activate.on-profile: local, test
 

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -1,34 +1,51 @@
 package kr.hhplus.be.server;
 
 import jakarta.annotation.PreDestroy;
-import org.springframework.boot.test.context.TestConfiguration;
-import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
 @Configuration
 class TestcontainersConfiguration {
 
-	public static final MySQLContainer<?> MYSQL_CONTAINER;
+    private static final String REDIS_IMAGE = "redis:7.0.8";
+    private static final int REDIS_PORT = 6379;
+    private static final String MYSQL_IMAGE = "mysql:8.0";
 
-	static {
-		MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse("mysql:8.0"))
-			.withDatabaseName("hhplus")
-			.withUsername("test")
-			.withPassword("test");
-		MYSQL_CONTAINER.start();
+    private static final GenericContainer REDIS_CONTAINER;
+    private static final MySQLContainer<?> MYSQL_CONTAINER;
 
-		System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
-		System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
-		System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
-	}
+    static {
+        REDIS_CONTAINER = new GenericContainer<>(REDIS_IMAGE)
+                .withExposedPorts(REDIS_PORT)
+                .withReuse(true);
+        MYSQL_CONTAINER = new MySQLContainer<>(DockerImageName.parse(MYSQL_IMAGE))
+                .withDatabaseName("hhplus")
+                .withUsername("test")
+                .withPassword("test");
 
-	@PreDestroy
-	public void preDestroy() {
-		if (MYSQL_CONTAINER.isRunning()) {
-			MYSQL_CONTAINER.stop();
-		}
-	}
+        REDIS_CONTAINER.start();
+        MYSQL_CONTAINER.start();
+        System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
+        System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
+        System.setProperty("spring.datasource.username", MYSQL_CONTAINER.getUsername());
+        System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
+
+        System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
+        System.setProperty("spring.data.redis.port", REDIS_CONTAINER.getMappedPort(REDIS_PORT).toString());
+    }
+
+    @PreDestroy
+    public void preDestroy() {
+        if (MYSQL_CONTAINER.isRunning()) {
+            MYSQL_CONTAINER.stop();
+        }
+
+        if (REDIS_CONTAINER.isRunning()) {
+            REDIS_CONTAINER.stop();
+        }
+    }
 }

--- a/src/test/java/kr/hhplus/be/server/domain/coupon/CouponServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/coupon/CouponServiceTest.java
@@ -116,7 +116,7 @@ class CouponServiceTest {
 
             when(couponRepository.existsCouponIssueByUserAndCouponId(user, 1L))
                     .thenReturn(false);
-            when(couponRepository.findCouponByIdWithLock(1L))
+            when(couponRepository.findCouponById(1L))
                     .thenReturn(Optional.empty());
 
             CouponIssueCommand command = CouponIssueCommand.of(1L);
@@ -136,7 +136,7 @@ class CouponServiceTest {
 
             when(couponRepository.existsCouponIssueByUserAndCouponId(user, 1L))
                     .thenReturn(false);
-            when(couponRepository.findCouponByIdWithLock(1L))
+            when(couponRepository.findCouponById(1L))
                     .thenReturn(Optional.of(coupon));
             when(couponRepository.saveCouponIssue(CouponIssue.of(user, coupon)))
                     .thenReturn(CouponIssue.of(user, coupon));
@@ -159,7 +159,7 @@ class CouponServiceTest {
 
             when(couponRepository.existsCouponIssueByUserAndCouponId(user, 1L))
                     .thenReturn(false);
-            when(couponRepository.findCouponByIdWithLock(1L))
+            when(couponRepository.findCouponById(1L))
                     .thenReturn(Optional.of(coupon));
             when(couponRepository.saveCouponIssue(CouponIssue.of(user, coupon)))
                     .thenReturn(CouponIssue.of(user, coupon));
@@ -170,7 +170,7 @@ class CouponServiceTest {
             couponService.issueCoupon(user, command);
 
             //then
-            verify(couponRepository, times(1)).findCouponByIdWithLock(1L);
+            verify(couponRepository, times(1)).findCouponById(1L);
         }
 
         @Test
@@ -182,7 +182,7 @@ class CouponServiceTest {
 
             when(couponRepository.existsCouponIssueByUserAndCouponId(user, 1L))
                     .thenReturn(false);
-            when(couponRepository.findCouponByIdWithLock(1L))
+            when(couponRepository.findCouponById(1L))
                     .thenReturn(Optional.of(coupon));
             when(couponRepository.saveCouponIssue(CouponIssue.of(user, coupon)))
                     .thenReturn(CouponIssue.of(user, coupon));


### PR DESCRIPTION
## PR 설명
<!-- 해당 PR이 왜 발생했고, 어떤부분에 대한 작업인지 작성해주세요. -->

- Redis 연동 : [2775996](https://github.com/joona95/hhplus-ecommerce/pull/43/commits/27759960fa1313d24504bef40f6d6d59a6aa38a5)
- AOP 분산락 구현 : [95d33b8](https://github.com/joona95/hhplus-ecommerce/pull/43/commits/95d33b8a41f344485fb329fbe95451f3bac993aa)
- 선착순 쿠폰 발급 분산락 적용 : [e3552b2](https://github.com/joona95/hhplus-ecommerce/pull/43/commits/e3552b27d47f1414474505a3c3e173ebc02174d0)

## 리뷰 포인트
<!-- 
    리뷰어가 함께 고민해주었으면 하는 내용을 간략하게 기재해주세요.
    커밋 링크가 포함되면, 더욱이 효과적일 거예요! 
-->

분산락을 학습하기 위해, 우선은 프로젝트가 DB락에서 분산락으로 바꿔야 하는 시점이라는 가정을 하고 진행하였습니다. 캐시 활용 작업도 진행할 예정으로 Redis를 사용하여 분산락을 구현해봤습니다. 

분산락 처리 로직이 비즈니스 로직에 오염되지 않도록 AOP 로 분리하여 진행하였습니다. 또한, 락 실행과 해제가 트랜잭션 시작과 종료보다 먼저 일어나도록 처리가 일어날 수 있게끔 했습니다.

현재 선착순 쿠폰 발급과 재고 차감에서는 비관적 락을 사용하여 동시성 문제를 제어하고 있고, 포인트 충전/차감 시에는 낙관적 락을 사용하여 동시성 문제를 제어하고 있습니다. 

DB 락을 사용하고 있는 각각의 시나리오에 맞춰 분산락으로 전환하는 작업을 진행할지 여부와 이유에 대해서 정리를 해봤습니다.

**1. 선착순 쿠폰 발급**

선착순 쿠폰 발급의 경우, 이벤트성으로 발생하는 경우가 많아 같은 쿠폰에 대한 동시 요청이 많이 발생할 수 있고 충돌이 잦을 수 있고 한 명이 성공하고 다른 사람들이 다 실패한 사이 들어온 요청이 먼저 쿠폰 발급 받아서는 안되기 때문에 비관적 락을 걸어 동시성 이슈를 제어하고자 했습니다.

이벤트 트래픽이 많아지면서 마이크로 서비스 전환, 다중 서버/DB 환경으로 전환된 상황을 가정하였을 때, 충돌이 많이 발생하는 상황에서 선착순 쿠폰 발급의 비관적 락을 지속하기에는 DB 부하가 많아지고 데드락 발생 가능성이 급증할 수 있고 다중 서버/DB 환경으로 동시성 문제가 계속 발생할 수 있습니다.

분산락으로 전환하여 다중 서버/DB 환경에서도 동시성 문제를 제어하는 한편 락 제어를 메모리 계층에서 하면서 DB 부하를 줄이고자 했습니다.

**2. 포인트 충전/차감**

포인트 충전/차감의 경우, 동일 유저에 대해서 동시에 포인트 충전/차감 요청이 발생하는 경우가 어뷰징 유저거나 정기결제 등과 겹치는 케이스가 아니라면 잘 발생하지 않을 것이라고 생각하여 낙관적 락을 걸어 동시성 이슈를 제어하고자 했습니다.

분산 환경 전환으로 인해 낙관적 락으로는 동시성 문제를 제어하기 쉽지 않아 이 부분을 분산락으로 변경하는 부분에 대한 고민을 하였습니다.

그러나 동일 유저가 동일 시점에 두 요청을 보낼 확률이 낮은 부분에서 오히려 락 획득/해제로 인한 네트워크 비용이 더 많이 발생 할 수 있겠다는 판단이 들었습니다. 또한 낙관적 락도 DB 부하를 주는 물리적 락이 아니기 때문에 효율적일까에 대한 의문이 들었습니다.

포인트 충전/차감의 경우, 낙관적 락을 유지하고 실패율을 모니터링하다가 충돌이 많아지는 시점에 분산락을 검토하는 방향으로 생각하기로 했습니다.


**3. 재고 차감**

재고 차감의 경우, 이벤트가 있는 경우 동시에 수많은 주문 요청이 발생할 가능성이 있어서 충돌이 잦아질 수 있고 주문 요청이 동시에 들어왔을 때 한 명만 성공하고 다른 사람들은 다 실패 후 재시도 처리하면 부하가 많아질 가능성이 있기 때문에 비관적 락을 걸어 동시성 이슈를 제어하고자 했습니다.

이벤트 트래픽이 많아지면서 마이크로 서비스 전환, 다중 서버/DB 환경으로 전환된 상황을 가정하였을 때, 충돌이 많이 발생하는 상황에서 재고 차감의 비관적 락을 지속하기에는 DB 부하가 많아지고 데드락 발생 가능성이 급증할 수 있고 다중 서버/DB 환경으로 동시성 문제가 계속 발생할 수 있습니다.

분산락으로 전환하는 것이 다중 서버/DB 환경에서도 동시성 문제를 제어하는 한편 락 제어를 메모리 계층에서 하면서 DB 부하를 줄일 수 있겠다고 생각했습니다.

그러나 재고 차감의 경우, 분산락을 적용하면 주문 전체 트랜잭션과는 별도로 트랜잭션이 실행될 것이므로 주문 실패 시 이벤트 발행을 통한 재고 보상 트랜잭션 처리가 필요할 것으로 보였습니다.

보상 트랜잭션은 보통 분산 환경에서 카프카 + Outbox 방식으로 구현하는 것으로 보였습니다. 현재 카프카를 사용하지 않는 상황에서 이벤트 발행을 위해 `@TransactionalEventListener` 이나 Redis Pub/Sub 을 이용할 수 있을 것으로 보였습니다.

그러나 분산 환경이라는 가정 하에 진행하고 있기 때문에 단일 환경 이벤트 발행에 적합한  `@TransactionalEventListener` 은 의미가 없을 것으로 보였고, Redis Pub/Sub 데이터 유실이 발생할 것으로 보였습니다. 

추후 과정에서 카프카와 이벤트 발행 과정에 들어갔을 때, 분산락을 도입해보는 것을 고려해보기로 했습니다. 그리고 선착순 쿠폰 발행과는 달리, 주문은 특정 이벤트 발생 시에만 같은 상품에 대한 주문이 몰릴 것으로 예상되어 비관적 락을 유지해도 평상시에는 동시성 이슈 처리에 충분할 것이라고 생각됐습니다.


## Definition of Done (DoD)
<!--
    DOD 란 해당 작업을 완료했다고 간주하기 위해 충족해야 하는 기준을 의미합니다.
    어떤 기능을 위해 어떤 요구사항을 만족하였으며, 어떤 테스트를 수행했는지 등을 명확하게 체크리스트로 기재해 주세요.
    리뷰어 입장에서, 모든 맥락을 파악하기 이전에 작업의 성숙도/완성도를 파악하는 데에 도움이 됩니다.
    만약 계획되거나 연관 작업이나 파생 작업이 존재하는데, 이후로 미뤄지는 경우 TODO -, 사유와 함께 적어주세요.

    ex:
    - [x] 상품 도메인 모델 구조 설계 완료 ( [정책 참고자료](관련 문서 링크) )
    - [x] 상품 재고 차감 로직 유닛/통합 테스트 완료
    - [ ] TODO - 상품 주문 로직 개발 ( 정책 미수립으로 인해 후속 작업에서 진행 )
-->

- [x] Redis 연동
- [x] AOP 분산락 구현
- [x] 선착순 쿠폰 발급 분산락 적용