### PR TITLE
[STEP-18] 선착순 쿠폰 발행 시 Kafka 적용 및 보고서 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
 	testImplementation("org.testcontainers:mysql")
 	testImplementation("com.redis.testcontainers:testcontainers-redis-junit:1.6.4")
 	testImplementation("org.testcontainers:kafka:1.20.1")
+	testImplementation("org.springframework.kafka:spring-kafka-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
 
 	// lombok

--- a/docs/kafka_coupon_issue.md
+++ b/docs/kafka_coupon_issue.md
@@ -1,0 +1,167 @@
+# Kafka 선착순 쿠폰 발급 적용 보고서
+
+## 서론
+
+선착순 쿠폰 발급 기능은 다수의 사용자가가 거의 동시에 접근할 때 동시성 이슈가 발생할 가능성이 있었습니다. 처음에는 DB 비관적 락을 통해 트랜잭션 레벨에서 동시성 문제를 제어하려 하였으나, 수많은 요청이 들어오면 모든 트랜잭션이 락을 대기하면서 DB 부하 및 응답 지연이 심각해지는 문제가 있었습니다.
+
+다음으로 단일 애플리케이션에서 여러 인스턴스로 확장한다고 가정하여, DB 부하를 줄이고 분산 환경에서 락 경합을 완화하기 위해 Redis 분산 락을 도입했습니다. 분산 락은 네트워크 지연이나 Redis 노드 장애 시 락 해제 실패로 데드락 위험이 있고, 높은 트래픽에서는 락 재시도로 인한 오버헤드가 발생할 수 있었습니다.
+
+이를 개선하기 위해 Redis Sorted Set 자료구조를 활용한 순차 큐 방식을 도입했습니다. 요청 시점의 타임스탬프를 score로 하여 ZADD 한 후, ZRANK 로 순번이 발급 가능 수량 이하일 때만 대기 리스트에 저장하고 1~3초 주기 배치로 쿠폰 발급하는 방식입니다. 이 방법은 DB 락을 최소화하고 Redis 레벨에서 동시성 제어할 수 있었으나, 여전히 배치 지연과 Redis 부하 (Sorted Set 연산, 배치 스캔), 및 배치 예외 복구 복잡성이라는 한계가 남아 있었습니다. 
+
+따라서, MSA 규모의 높은 트래픽과 실시간성을 요구하는 환경에서 Redis 단독 처리로는 한계가 있다고 판단하여 Kafka 기반 실시간 이벤트 발행으로 전환하기로 하였습니다.
+
+<br>
+
+## 기존 : Redis + DB 활용
+
+### 요청 처리 플로우
+
+```
+1) HTTP POST /coupons/{couponId}/issue 선착순 쿠폰 발급 요청
+
+2) ZADD coupon-issue-token:{couponId} timestamp userId Sorted Set 자료구조에 선착순 쿠폰 발급 요청 저장
+
+3) coupon-issued:{couponId} userId 중복 발급 체크
+
+4) ZRANK 순번과 coupon-stock:{couponId} 발급 가능 수량 비교 → 발급 가능 수량 초과 시 ZREM (쿠폰 발급 수량 제한)
+
+5) 순번 이내 시 SADD coupon-issued:{couponId} userId (중복 발급 체크용) / LPUSH coupon-issue-pending couponId (발급 요청된 쿠폰 목록)
+
+5) 1~3초 주기 배치: coupon-issue-pending 발급 요청된 쿠폰 목록 조회 → 중복 발급 체크 → DB 트랜잭션 쿠폰 발급내역 저장 → coupon-stock:{couponId} 발급 가능 수량 감소
+```
+
+### 문제점
+
+- **배치 지연**(1~3초)
+- **Redis 부하**(Sorted Set 연산 및 배치 스캔)
+- **운영 복잡성**(배치 실패 시 상태 동기화)
+- **MSA 확장성 부족**(단일 배치 스케줄러 의존)
+
+<br>
+
+## 변경 : Kafka + Redis + DB 활용
+
+### 아키텍쳐 구조
+
+```
+클라이언트 → Kafka Producer → topic: coupon-issue-request(key=couponId) → Consumer Group(concurrency=P) → Redis(Set+Counter) + DB 트랜잭션
+```
+
+- **Producer**: HTTP 요청 직후 `KafkaTemplate.send("coupon-issue-request", couponId, userId)`
+- **Topic**: 파티션 6, 복제팩터 3 (key 기반 파티셔닝으로 couponId별 순차성 보장)
+- **Consumer**: `@KafkaListener(concurrency=6)`, Set + Counter 조합으로 중복 발급 체크 및 쿠폰 발급 수량 제한 처리
+- **Redis**: `SADD`로 중복 발급 차단, `Counter`로 쿠폰 발급 수량 제한
+- **DB**: 트랜재션 내 재고 차감 및 발급 이력 저장
+
+#### Kafka 활용
+
+```java
+@Configuration
+public class KafkaTopicConfig {
+    //...
+
+    @Bean
+    public NewTopic couponIssueRequestTopic() {
+        return TopicBuilder
+                .name("coupon-issue-request")
+                .partitions(6)
+                .replicas(3)
+                .build();
+    }
+}
+```
+```java
+@Slf4j
+@Component
+public class CouponKafkaEventPublisher implements CouponEventPublisher {
+
+    private static final String COUPON_ISSUE_REQUEST_TOPIC = "coupon-issue-request";
+    private final KafkaTemplate<String, CouponIssueRequestEvent> kafkaTemplate;
+
+    public CouponKafkaEventPublisher(KafkaTemplate<String, CouponIssueRequestEvent> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    @Override
+    public void send(CouponIssueRequestEvent event) {
+        log.info("Produce message : " + event);
+        this.kafkaTemplate.send(COUPON_ISSUE_REQUEST_TOPIC, String.valueOf(event.couponId()), event);
+    }
+}
+```
+```java
+@Slf4j
+@Component
+public class CouponEventListener {
+
+    private final CouponService couponService;
+
+    public CouponEventListener(CouponService couponService) {
+        this.couponService = couponService;
+    }
+
+    @KafkaListener(topics = "coupon-issue-request", groupId = "coupon-issue", concurrency = "6")
+    public void handleCouponIssueRequestEvent(CouponIssueRequestEvent event) {
+
+        try {
+            couponService.handleCouponIssueRequest(event.userId(), event.couponId());
+            log.info("선착순 쿠폰 발급 완료");
+        } catch (Exception e) {
+            log.error("선착순 쿠폰 발급 실패");
+        }
+    }
+}
+```
+
+- 요청을 토픽에 쌓아 주문 요청 트래픽이 몰릴 때도 안정적으로 처리 가능
+
+- (key = couponId) 기반 파티셔닝으로 couponId 별 선착순 보장 가능
+
+- 파티션 수와 컨슈머 수 조정으로 처리량 선형 확장 가능
+
+- 디스크 로그 보존 및 오프셋 재조정으로 장애 복구 및 재실행 지원 가능
+
+#### Redis 활용
+
+```
+    public void handleCouponIssueRequest(long userId, long couponId) {
+
+        CouponIssueToken couponIssueToken = CouponIssueToken.of(userId, couponId);
+
+        if (couponIssueTokenRepository.isAlreadyIssued(couponIssueToken)) {
+            throw new RuntimeException("이미 쿠폰 발급 요청한 유저입니다.");
+        }
+
+        long couponStock = couponRepository.getCouponStock(couponId);
+        long issuedSize = couponIssueTokenRepository.countCouponIssuedUser(couponIssueToken);
+        if (couponStock < issuedSize) {
+            throw new RuntimeException("쿠폰 발급 가능한 수량을 초과하였습니다.");
+        }
+
+        couponIssueTokenRepository.saveCouponIssuedUser(couponIssueToken);
+
+        issueCoupon(userId, couponId);
+    }
+```
+
+- Redis 에서 중복 발급 방지(Set) 및 발급 수량 제어(Counter) 용도로 최소화하여 사용
+
+#### DB 활용
+
+```java
+    @Transactional
+    public void issueCoupon(long userId, long couponId) {
+
+        Coupon coupon = couponRepository.findCouponById(couponId).orElseThrow(() -> new RuntimeException("존재하지 않는 쿠폰입니다."));
+
+        if (couponRepository.existsCouponIssueByUserIdAndCouponId(userId, coupon.getId())) {
+            throw new RuntimeException("쿠폰을 이미 발급 받았습니다.");
+        }
+        coupon.issue();
+        couponRepository.saveCouponIssue(CouponIssue.of(userId, coupon));
+        couponRepository.saveCouponStock(coupon.getId(), coupon.getCount());
+    }
+```
+
+- 최종 DB 트랜잭션에서 재고 차감 및 발급 이력 저장으로 일관성과 안정성을 확보
+

--- a/src/main/java/kr/hhplus/be/server/application/coupon/CouponFacadeService.java
+++ b/src/main/java/kr/hhplus/be/server/application/coupon/CouponFacadeService.java
@@ -1,0 +1,21 @@
+package kr.hhplus.be.server.application.coupon;
+
+import kr.hhplus.be.server.domain.coupon.CouponCommand;
+import kr.hhplus.be.server.domain.coupon.CouponEventPublisher;
+import kr.hhplus.be.server.domain.coupon.CouponIssueRequestEvent;
+import kr.hhplus.be.server.domain.user.User;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CouponFacadeService {
+
+    private final CouponEventPublisher couponEventPublisher;
+
+    public CouponFacadeService(CouponEventPublisher couponEventPublisher) {
+        this.couponEventPublisher = couponEventPublisher;
+    }
+
+    public void requestCouponIssue(User user, CouponCommand.CouponIssueCommand command) {
+        couponEventPublisher.send(new CouponIssueRequestEvent(command.couponId(), user.getId()));
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/config/kafka/KafkaTopicConfig.java
+++ b/src/main/java/kr/hhplus/be/server/config/kafka/KafkaTopicConfig.java
@@ -16,4 +16,13 @@ public class KafkaTopicConfig {
                 .replicas(3)
                 .build();
     }
+
+    @Bean
+    public NewTopic couponIssueRequestTopic() {
+        return TopicBuilder
+                .name("coupon-issue-request")
+                .partitions(6)
+                .replicas(3)
+                .build();
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponEventPublisher.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponEventPublisher.java
@@ -1,0 +1,6 @@
+package kr.hhplus.be.server.domain.coupon;
+
+public interface CouponEventPublisher {
+
+    void send(CouponIssueRequestEvent event);
+}

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponIssueRequestEvent.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponIssueRequestEvent.java
@@ -1,0 +1,8 @@
+package kr.hhplus.be.server.domain.coupon;
+
+public record CouponIssueRequestEvent(
+        long couponId,
+        long userId
+) {
+
+}

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponIssueToken.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponIssueToken.java
@@ -10,7 +10,11 @@ public record CouponIssueToken(
         long requestTime
 ) {
     public static CouponIssueToken of(User user, long couponId) {
-        return new CouponIssueToken(user.getId(), couponId, System.currentTimeMillis());
+        return CouponIssueToken.of(user.getId(), couponId);
+    }
+
+    public static CouponIssueToken of(long userId, long couponId) {
+        return new CouponIssueToken(userId, couponId, System.currentTimeMillis());
     }
 
     @Override

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponIssueTokenRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponIssueTokenRepository.java
@@ -25,4 +25,6 @@ public interface CouponIssueTokenRepository {
     boolean isAlreadyIssued(CouponIssueToken couponIssueToken);
 
     void saveCouponIssuedUser(CouponIssueToken couponIssueToken);
+
+    long countCouponIssuedUser(CouponIssueToken couponIssueToken);
 }

--- a/src/main/java/kr/hhplus/be/server/domain/coupon/CouponRepository.java
+++ b/src/main/java/kr/hhplus/be/server/domain/coupon/CouponRepository.java
@@ -3,6 +3,7 @@ package kr.hhplus.be.server.domain.coupon;
 import kr.hhplus.be.server.domain.user.User;
 import org.springframework.stereotype.Repository;
 
+import javax.swing.text.html.Option;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -25,4 +26,6 @@ public interface CouponRepository {
     List<Coupon> findCouponsByIdIn(Collection<Long> pendingCouponIds);
 
     void saveCouponStock(long couponId, int count);
+
+    Optional<Coupon> findCouponById(long couponId);
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponCacheRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponCacheRepository.java
@@ -31,4 +31,6 @@ public interface CouponCacheRepository {
     boolean isAlreadyIssued(CouponIssueToken couponIssueToken);
 
     void saveCouponIssuedUser(CouponIssueToken couponIssueToken);
+
+    long countCouponIssuedUser(CouponIssueToken couponIssueToken);
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponIssueJpaRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponIssueJpaRepository.java
@@ -1,7 +1,6 @@
 package kr.hhplus.be.server.infrastructure.coupon;
 
 import kr.hhplus.be.server.domain.coupon.CouponIssue;
-import kr.hhplus.be.server.domain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -14,4 +13,6 @@ public interface CouponIssueJpaRepository extends JpaRepository<CouponIssue, Lon
     Optional<CouponIssue> findByUserIdAndCouponId(long userId, long couponId);
 
     boolean existsByUserIdAndCouponId(long userId, long couponId);
+
+    long countByCouponId(long couponId);
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponIssueTokenRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponIssueTokenRepositoryImpl.java
@@ -61,4 +61,9 @@ public class CouponIssueTokenRepositoryImpl implements CouponIssueTokenRepositor
     public void saveCouponIssuedUser(CouponIssueToken couponIssueToken) {
         couponCacheRepository.saveCouponIssuedUser(couponIssueToken);
     }
+
+    @Override
+    public long countCouponIssuedUser(CouponIssueToken couponIssueToken) {
+        return couponCacheRepository.countCouponIssuedUser(couponIssueToken);
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponKafkaEventPublisher.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponKafkaEventPublisher.java
@@ -1,0 +1,25 @@
+package kr.hhplus.be.server.infrastructure.coupon;
+
+import kr.hhplus.be.server.domain.coupon.CouponEventPublisher;
+import kr.hhplus.be.server.domain.coupon.CouponIssueRequestEvent;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CouponKafkaEventPublisher implements CouponEventPublisher {
+
+    private static final String COUPON_ISSUE_REQUEST_TOPIC = "coupon-issue-request";
+    private final KafkaTemplate<String, CouponIssueRequestEvent> kafkaTemplate;
+
+    public CouponKafkaEventPublisher(KafkaTemplate<String, CouponIssueRequestEvent> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    @Override
+    public void send(CouponIssueRequestEvent event) {
+        log.info("Produce message : " + event);
+        this.kafkaTemplate.send(COUPON_ISSUE_REQUEST_TOPIC, String.valueOf(event.couponId()), event);
+    }
+}

--- a/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponRedissonRepository.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponRedissonRepository.java
@@ -98,4 +98,10 @@ public class CouponRedissonRepository implements CouponCacheRepository {
         RSet<Long> rSet = redissonClient.getSet(COUPON_ISSUED_PREFIX + couponIssueToken.couponId(), LongCodec.INSTANCE);
         rSet.add(couponIssueToken.userId());
     }
+
+    @Override
+    public long countCouponIssuedUser(CouponIssueToken couponIssueToken) {
+        RSet<Long> rSet = redissonClient.getSet(COUPON_ISSUED_PREFIX + couponIssueToken.couponId(), LongCodec.INSTANCE);
+        return rSet.size();
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponRepositoryImpl.java
+++ b/src/main/java/kr/hhplus/be/server/infrastructure/coupon/CouponRepositoryImpl.java
@@ -68,4 +68,9 @@ public class CouponRepositoryImpl implements CouponRepository {
     public void saveCouponStock(long couponId, int count) {
         couponCacheRepository.saveCouponStock(couponId, count);
     }
+
+    @Override
+    public Optional<Coupon> findCouponById(long couponId) {
+        return couponJpaRepository.findById(couponId);
+    }
 }

--- a/src/main/java/kr/hhplus/be/server/interfaces/coupon/CouponController.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/coupon/CouponController.java
@@ -1,6 +1,7 @@
 package kr.hhplus.be.server.interfaces.coupon;
 
 import jakarta.validation.Valid;
+import kr.hhplus.be.server.application.coupon.CouponFacadeService;
 import kr.hhplus.be.server.domain.coupon.CouponService;
 import kr.hhplus.be.server.domain.user.User;
 import org.springframework.http.ResponseEntity;
@@ -19,9 +20,11 @@ import static kr.hhplus.be.server.interfaces.coupon.CouponResponse.*;
 @RequestMapping("/api/v1/coupons")
 public class CouponController implements CouponApiSpec {
 
+    private final CouponFacadeService couponFacadeService;
     private final CouponService couponService;
 
-    public CouponController(CouponService couponService) {
+    public CouponController(CouponFacadeService couponFacadeService, CouponService couponService) {
+        this.couponFacadeService = couponFacadeService;
         this.couponService = couponService;
     }
 
@@ -40,7 +43,7 @@ public class CouponController implements CouponApiSpec {
     @Override
     public ResponseEntity<Void> issueCoupon(User user, @RequestBody @Valid CouponIssueRequest request) {
 
-        couponService.requestCouponIssue(user, request.toCommand());
+        couponFacadeService.requestCouponIssue(user, request.toCommand());
 
         return ResponseEntity.ok().build();
     }

--- a/src/main/java/kr/hhplus/be/server/interfaces/coupon/CouponEventListener.java
+++ b/src/main/java/kr/hhplus/be/server/interfaces/coupon/CouponEventListener.java
@@ -1,0 +1,29 @@
+package kr.hhplus.be.server.interfaces.coupon;
+
+import kr.hhplus.be.server.domain.coupon.CouponIssueRequestEvent;
+import kr.hhplus.be.server.domain.coupon.CouponService;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CouponEventListener {
+
+    private final CouponService couponService;
+
+    public CouponEventListener(CouponService couponService) {
+        this.couponService = couponService;
+    }
+
+    @KafkaListener(topics = "coupon-issue-request", groupId = "coupon-issue", concurrency = "6")
+    public void handleCouponIssueRequestEvent(CouponIssueRequestEvent event) {
+
+        try {
+            couponService.handleCouponIssueRequest(event.userId(), event.couponId());
+            log.info("선착순 쿠폰 발급 완료");
+        } catch (Exception e) {
+            log.error("선착순 쿠폰 발급 실패");
+        }
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
+++ b/src/test/java/kr/hhplus/be/server/TestcontainersConfiguration.java
@@ -3,7 +3,6 @@ package kr.hhplus.be.server;
 import jakarta.annotation.PreDestroy;
 import org.springframework.context.annotation.Configuration;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.utility.DockerImageName;
 
@@ -17,7 +16,7 @@ class TestcontainersConfiguration {
 
     private static final GenericContainer REDIS_CONTAINER;
     private static final MySQLContainer<?> MYSQL_CONTAINER;
-    private static final KafkaContainer KAFKA_CONTAINER;
+//    private static final KafkaContainer KAFKA_CONTAINER;
 
     static {
         REDIS_CONTAINER = new GenericContainer<>(REDIS_IMAGE)
@@ -27,12 +26,14 @@ class TestcontainersConfiguration {
                 .withDatabaseName("hhplus")
                 .withUsername("test")
                 .withPassword("test");
-        KAFKA_CONTAINER = new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE))
-                .withKraft();
+//        KAFKA_CONTAINER = new KafkaContainer(DockerImageName.parse(KAFKA_IMAGE))
+//                .withKraft()
+//                .withEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "true")
+//                .withEnv("KAFKA_NUM_PARTITIONS", "3");
 
         REDIS_CONTAINER.start();
         MYSQL_CONTAINER.start();
-        KAFKA_CONTAINER.start();
+//        KAFKA_CONTAINER.start();
 
         System.setProperty("spring.datasource.password", MYSQL_CONTAINER.getPassword());
         System.setProperty("spring.datasource.url", MYSQL_CONTAINER.getJdbcUrl() + "?characterEncoding=UTF-8&serverTimezone=UTC");
@@ -41,8 +42,8 @@ class TestcontainersConfiguration {
 
         System.setProperty("spring.data.redis.host", REDIS_CONTAINER.getHost());
         System.setProperty("spring.data.redis.port", REDIS_CONTAINER.getMappedPort(REDIS_PORT).toString());
-
-        System.setProperty("spring.kafka.bootstrap-servers", KAFKA_CONTAINER.getBootstrapServers());
+//
+//        System.setProperty("spring.kafka.bootstrap-servers", KAFKA_CONTAINER.getBootstrapServers());
     }
 
     @PreDestroy
@@ -54,9 +55,9 @@ class TestcontainersConfiguration {
         if (REDIS_CONTAINER.isRunning()) {
             REDIS_CONTAINER.stop();
         }
-
-        if (KAFKA_CONTAINER.isRunning()) {
-            KAFKA_CONTAINER.stop();
-        }
+//
+//        if (KAFKA_CONTAINER.isRunning()) {
+//            KAFKA_CONTAINER.stop();
+//        }
     }
 }

--- a/src/test/java/kr/hhplus/be/server/application/coupon/CouponFacadeServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/coupon/CouponFacadeServiceTest.java
@@ -1,0 +1,78 @@
+package kr.hhplus.be.server.application.coupon;
+
+import kr.hhplus.be.server.domain.coupon.Coupon;
+import kr.hhplus.be.server.domain.coupon.CouponCommand;
+import kr.hhplus.be.server.domain.coupon.CouponService;
+import kr.hhplus.be.server.domain.user.User;
+import kr.hhplus.be.server.fixtures.CouponFixtures;
+import kr.hhplus.be.server.fixtures.UserFixtures;
+import kr.hhplus.be.server.infrastructure.coupon.CouponJpaRepository;
+import kr.hhplus.be.server.infrastructure.support.DatabaseCleanup;
+import kr.hhplus.be.server.infrastructure.support.RedisCleanup;
+import kr.hhplus.be.server.infrastructure.user.UserJpaRepository;
+import kr.hhplus.be.server.interfaces.coupon.CouponEventListener;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.shaded.org.awaitility.Awaitility;
+
+import java.time.Duration;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+@Testcontainers
+@EmbeddedKafka
+public class CouponFacadeServiceTest {
+
+    @Autowired
+    private CouponService couponService;
+    @Autowired
+    private CouponFacadeService couponFacadeService;
+    @MockitoSpyBean
+    private CouponEventListener couponEventListener;
+
+    @Autowired
+    private UserJpaRepository userJpaRepository;
+    @Autowired
+    private CouponJpaRepository couponJpaRepository;
+
+    @Autowired
+    private DatabaseCleanup databaseCleanup;
+    @Autowired
+    private RedisCleanup redisCleanup;
+
+    @BeforeEach
+    void setUp() {
+        databaseCleanup.truncateAllTables();
+        redisCleanup.flushAll();
+    }
+
+    @Test
+    void 쿠폰_발급_요청_시_쿠폰_발급_처리() {
+
+        //given
+        User user = userJpaRepository.save(UserFixtures.정상_유저_생성());
+        Coupon coupon = couponJpaRepository.save(CouponFixtures.정상_쿠폰_생성());
+        CouponCommand.CouponIssueCommand command = CouponCommand.CouponIssueCommand.of(coupon.getId());
+
+        //when
+        couponFacadeService.requestCouponIssue(user, command);
+
+        //then
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(60))
+                .untilAsserted(() -> {
+                    verify(couponEventListener, times(1)).handleCouponIssueRequestEvent(any());
+                });
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/application/order/OrderFacadeServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/application/order/OrderFacadeServiceTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import org.testcontainers.shaded.org.awaitility.Awaitility;
@@ -38,6 +39,7 @@ import static org.mockito.Mockito.*;
 @ExtendWith(MockitoExtension.class)
 @SpringBootTest
 @Testcontainers
+@EmbeddedKafka
 public class OrderFacadeServiceTest {
 
     @Autowired

--- a/src/test/java/kr/hhplus/be/server/domain/coupon/CouponConcurrencyTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/coupon/CouponConcurrencyTest.java
@@ -116,7 +116,7 @@ public class CouponConcurrencyTest {
         for (int i = 0; i < threadCount; i++) {
             executorService.execute(() -> {
                 try {
-                    couponService.issueCoupon(user.getId(), coupon);
+                    couponService.issueCoupon(user.getId(), coupon.getId());
                 } catch (Exception e) {
                     failureCount.incrementAndGet();
                 }
@@ -139,4 +139,6 @@ public class CouponConcurrencyTest {
 
         System.out.println("실패 횟수 : " + failureCount.get());
     }
+
+
 }

--- a/src/test/java/kr/hhplus/be/server/domain/coupon/CouponServiceIntegrationTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/coupon/CouponServiceIntegrationTest.java
@@ -61,7 +61,7 @@ public class CouponServiceIntegrationTest {
             Coupon coupon = couponJpaRepository.save(CouponFixtures.정상_쿠폰_생성());
 
             // when
-            couponService.issueCoupon(user.getId(), coupon);
+            couponService.issueCoupon(user.getId(), coupon.getId());
 
             // then
             assertThat(couponIssueJpaRepository.findAll()).hasSize(1);

--- a/src/test/java/kr/hhplus/be/server/domain/coupon/CouponServiceTest.java
+++ b/src/test/java/kr/hhplus/be/server/domain/coupon/CouponServiceTest.java
@@ -102,11 +102,13 @@ class CouponServiceTest {
             User user = UserFixtures.식별자로_유저_생성(1L);
             Coupon coupon = CouponFixtures.식별자로_쿠폰_생성(1L);
 
+            when(couponRepository.findCouponById(coupon.getId()))
+                    .thenReturn(Optional.of(coupon));
             when(couponRepository.existsCouponIssueByUserIdAndCouponId(user.getId(), coupon.getId()))
                     .thenReturn(true);
 
             //when, then
-            assertThatThrownBy(() -> couponService.issueCoupon(user.getId(), coupon))
+            assertThatThrownBy(() -> couponService.issueCoupon(user.getId(), coupon.getId()))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("쿠폰을 이미 발급 받았습니다.");
         }
@@ -118,11 +120,13 @@ class CouponServiceTest {
             User user = UserFixtures.식별자로_유저_생성(1L);
             Coupon coupon = CouponFixtures.식별자로_쿠폰_생성(1L);
 
+            when(couponRepository.findCouponById(coupon.getId()))
+                    .thenReturn(Optional.of(coupon));
             when(couponRepository.existsCouponIssueByUserIdAndCouponId(user.getId(), coupon.getId()))
                     .thenReturn(false);
 
             //when
-            couponService.issueCoupon(user.getId(), coupon);
+            couponService.issueCoupon(user.getId(), coupon.getId());
 
             //then
             verify(couponRepository, times(1)).saveCouponIssue(CouponIssue.of(user.getId(), coupon));
@@ -136,11 +140,13 @@ class CouponServiceTest {
             Coupon coupon = CouponFixtures.식별자로_쿠폰_생성(1L);
             int stock = coupon.getCount();
 
+            when(couponRepository.findCouponById(coupon.getId()))
+                    .thenReturn(Optional.of(coupon));
             when(couponRepository.existsCouponIssueByUserIdAndCouponId(user.getId(), coupon.getId()))
                     .thenReturn(false);
 
             //when
-            couponService.issueCoupon(user.getId(), coupon);
+            couponService.issueCoupon(user.getId(), coupon.getId());
 
             //then
             verify(couponRepository, times(1)).saveCouponStock(coupon.getId(), stock - 1);
@@ -153,11 +159,13 @@ class CouponServiceTest {
             User user = UserFixtures.식별자로_유저_생성(1L);
             Coupon coupon = CouponFixtures.식별자로_쿠폰_생성(1L);
 
+            when(couponRepository.findCouponById(coupon.getId()))
+                    .thenReturn(Optional.of(coupon));
             when(couponRepository.existsCouponIssueByUserIdAndCouponId(user.getId(), 1L))
                     .thenReturn(true);
 
             //when, then
-            assertThatThrownBy(() -> couponService.issueCoupon(user.getId(), coupon))
+            assertThatThrownBy(() -> couponService.issueCoupon(user.getId(), coupon.getId()))
                     .isInstanceOf(RuntimeException.class);
 
             verify(couponRepository, times(0)).saveCouponIssue(CouponIssue.of(user.getId(), coupon));

--- a/src/test/java/kr/hhplus/be/server/interfaces/coupon/CouponEventListenerTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/coupon/CouponEventListenerTest.java
@@ -1,0 +1,37 @@
+package kr.hhplus.be.server.interfaces.coupon;
+
+import kr.hhplus.be.server.domain.coupon.CouponIssueRequestEvent;
+import kr.hhplus.be.server.domain.coupon.CouponService;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class CouponEventListenerTest {
+
+    @Mock
+    private CouponService couponService;
+
+    @InjectMocks
+    private CouponEventListener couponEventListener;
+
+    @Test
+    void 쿠폰_발급_요청_이벤트_발행_시_쿠폰_발급() {
+
+        //given
+        long userId = 1L;
+        long couponId = 1L;
+        CouponIssueRequestEvent event = new CouponIssueRequestEvent(couponId, userId);
+
+        //when
+        couponEventListener.handleCouponIssueRequestEvent(event);
+
+        //then
+        verify(couponService, times(1)).handleCouponIssueRequest(userId, couponId);
+    }
+}

--- a/src/test/java/kr/hhplus/be/server/interfaces/item/PopularItemEventListenerTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/item/PopularItemEventListenerTest.java
@@ -1,4 +1,4 @@
-package kr.hhplus.be.server.application.item;
+package kr.hhplus.be.server.interfaces.item;
 
 import kr.hhplus.be.server.domain.item.PopularItemService;
 import kr.hhplus.be.server.domain.order.Order;

--- a/src/test/java/kr/hhplus/be/server/interfaces/order/OrderEventListenerTest.java
+++ b/src/test/java/kr/hhplus/be/server/interfaces/order/OrderEventListenerTest.java
@@ -1,4 +1,4 @@
-package kr.hhplus.be.server.application.order;
+package kr.hhplus.be.server.interfaces.order;
 
 import kr.hhplus.be.server.application.client.DataPlatformClient;
 import kr.hhplus.be.server.domain.order.Order;


### PR DESCRIPTION
## PR 설명
<!-- 해당 PR이 왜 발생했고, 어떤부분에 대한 작업인지 작성해주세요. -->

- 선착순 쿠폰 발급 시 Kafka 적용 및 테스트 : [dd5a8d2](https://github.com/joona95/hhplus-ecommerce/pull/51/commits/dd5a8d2ac47252652067d0cb2e9708836cf4b3fb) [7fc3d9b](https://github.com/joona95/hhplus-ecommerce/pull/51/commits/7fc3d9b45c32152bc53376e06b3bcacbb420985b)
- 선착순 쿠폰 발급 시 Kafka 적용 보고서 : [d24c0e3](https://github.com/joona95/hhplus-ecommerce/pull/51/commits/d24c0e3e1384c40db6d0745886e3578a54d63cae)


## 리뷰 포인트
<!-- 
    리뷰어가 함께 고민해주었으면 하는 내용을 간략하게 기재해주세요.
    커밋 링크가 포함되면, 더욱이 효과적일 거예요! 
-->

- 선착순 쿠폰 발급 시에 카프카로 레디스나 디비 부하를 줄일 수 있을 것 같아, 요청 시에는 카프카에 이벤트 발행을 하도록 했습니다. 배치가 매초 도는 것도 큰 부하를 줄 수 있어서 요청을 조절해서 소비하면 효과적일 것 같았습니다. 그리고 동시성 이슈 제어를 위해서 레디스를 활용하여 중복발급이나 쿠폰 가능 수량 제한을 두고자 하였습니다. 
- 카프카 + 레디스 + DB 구조로 변경하였을 때 동시성 이슈 제어나 이벤트 발행이 잘 이루어지는지에 대한 테스트도 추가적으로 작성하여 동작을 확인하고 싶었습니다. 그러나 카프카 사용하는 테스트들은 하나만 돌릴 때는 괜찮은데 전체로 여러 테스트를 돌릴 때는 테스트가 제대로 이루어지지 않습니다. 값 검증보다는 그냥 단순히 호출 정상 동작 확인, 동시성 이슈 제어 등 정상 동작하는지 행위 검증만 하고자 하였던 건데, 카프카의 경우에는 이런식으로 여러 테스트 작성해서 검증은 불가한걸까요? 잘 동작하는지 확인은 어떤 식으로 보통 하나요? 
  - 그냥 카프카와 리스너 정상 동장 테스트 정도만 하고 로직 단위테스트만 시행하나요?  
  - 여러 시도해보다가.. 테스트 컨테이너 자체에서 카프카 설정했을 경우엔 테스트 정상 동작하지 않고, 카프카 사용하는 테스트에만 `@EmbeddedKafka` 설정 추가하면 되네요.. 뭔가 테스트 컨테이너 자체에서 설정하면 테스트 전체로 동작해서 리스너 수신과 검증 사이에서 뭔가 안 맞는 부분이 생기는가 싶기도 합니다..